### PR TITLE
Update Spec 4.7 with Routing Protocol

### DIFF
--- a/fabric/v4/api_routing_protocols.go
+++ b/fabric/v4/api_routing_protocols.go
@@ -27,6 +27,39 @@ var (
 
 type RoutingProtocolsApiService service
 
+
+func (a *RoutingProtocolsApiService) decodeRP(v *RoutingProtocolData, b []byte, contentType string) (err error) {
+	//get type of response body
+	var (
+		localVarReturnBGP    RoutingProtocolBgpData
+		localVarReturnDirect RoutingProtocolDirectData
+	)
+
+	err = a.client.decode(&v, b, contentType)
+	if err != nil {
+		return err
+	}
+	// decode response based on type, overwrite return value's oneof field
+	if v.Type_ == "BGP" {
+		// If we succeed, return the data, otherwise pass on to decode error.
+		err = a.client.decode(&localVarReturnBGP, b, contentType)
+		// try decoding as a bgp, return if no error
+		if err == nil {
+			v.RoutingProtocolBgpData = localVarReturnBGP
+			return err
+		}
+	}
+	if v.Type_ == "DIRECT" {
+		// try decoding as a direct rp
+		err = a.client.decode(&localVarReturnDirect, b, contentType)
+		if err == nil {
+			v.RoutingProtocolDirectData = localVarReturnDirect
+			return err
+		}
+	}
+	return err
+}
+
 /*
 RoutingProtocolsApiService Create Protocol
 This API provides capability to create Routing Protocol for connections
@@ -90,8 +123,8 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-		if err == nil {
+		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		if err != nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
 	}
@@ -103,7 +136,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v RoutingProtocolData
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
@@ -240,6 +273,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocolsInBulk(ctx 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
+		// fixme: why is this a get response?
 		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
@@ -389,7 +423,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
@@ -402,7 +436,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v RoutingProtocolData
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
@@ -701,7 +735,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
@@ -714,7 +748,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
 		}
 		if localVarHttpResponse.StatusCode == 200 {
 			var v RoutingProtocolData
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
@@ -1439,7 +1473,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
@@ -1452,7 +1486,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v RoutingProtocolData
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr
@@ -1743,7 +1777,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx 
 
 	if localVarHttpResponse.StatusCode < 300 {
 		// If we succeed, return the data, otherwise pass on to decode error.
-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 		if err == nil {
 			return localVarReturnValue, localVarHttpResponse, err
 		}
@@ -1756,7 +1790,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx 
 		}
 		if localVarHttpResponse.StatusCode == 202 {
 			var v RoutingProtocolData
-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
 			if err != nil {
 				newErr.error = err.Error()
 				return localVarReturnValue, localVarHttpResponse, newErr

--- a/fabric/v4/model_routing_protocol_base.go
+++ b/fabric/v4/model_routing_protocol_base.go
@@ -12,4 +12,5 @@ package v4
 type RoutingProtocolBase struct {
 	// Routing protocol type
 	Type_ string `json:"type,omitempty"`
+	OneOfRoutingProtocolBase
 }

--- a/fabric/v4/model_routing_protocol_data.go
+++ b/fabric/v4/model_routing_protocol_data.go
@@ -12,4 +12,5 @@ package v4
 type RoutingProtocolData struct {
 	// Routing protocol type
 	Type_ string `json:"type,omitempty"`
+	OneOfRoutingProtocolData
 }

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/manu-equinix/fabric-go
+module github.com/equinix-labs/fabric-go
 
 go 1.20
 

--- a/go.mod
+++ b/go.mod
@@ -4,12 +4,12 @@ go 1.20
 
 require (
 	github.com/antihax/optional v1.0.0
-	golang.org/x/oauth2 v0.8.0
+	golang.org/x/oauth2 v0.9.0
 )
 
 require (
 	github.com/golang/protobuf v1.5.2 // indirect
-	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/net v0.11.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/equinix-labs/fabric-go
+module github.com/manu-equinix/fabric-go
 
 go 1.20
 

--- a/go.sum
+++ b/go.sum
@@ -8,10 +8,10 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
-golang.org/x/oauth2 v0.8.0 h1:6dkIjl3j3LtZ/O3sTgZTMsLKSftL/B8Zgq4huOIIUu8=
-golang.org/x/oauth2 v0.8.0/go.mod h1:yr7u4HXZRm1R1kBWqr/xKNqewf0plRYoB7sla+BCIXE=
+golang.org/x/net v0.11.0 h1:Gi2tvZIJyBtO9SDr1q9h5hEQCp/4L2RQ+ar0qjx2oNU=
+golang.org/x/net v0.11.0/go.mod h1:2L/ixqYpgIVXmeoSA/4Lu7BzTG4KIyPIryS4IsOd1oQ=
+golang.org/x/oauth2 v0.9.0 h1:BPpt2kU7oMRq3kCHAA1tbSEshXRw1LpG2ztgDwrzuAs=
+golang.org/x/oauth2 v0.9.0/go.mod h1:qYgFZaFiu6Wg24azG8bdV52QJXJGbZzIIsRCdVKzbLw=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=

--- a/patches/post/08_model_routing_protocol_data.patch
+++ b/patches/post/08_model_routing_protocol_data.patch
@@ -4,7 +4,7 @@ index 0d754fd..1b1f45c 100644
 +++ b/fabric/v4/model_routing_protocol_data.go
 @@ -12,4 +12,5 @@ package v4
  type RoutingProtocolData struct {
-        // Routing protocol type
-        Type_ string `json:"type,omitempty"`
-+       OneOfRoutingProtocolData
+ 	// Routing protocol type
+ 	Type_ string `json:"type,omitempty"`
++	OneOfRoutingProtocolData
  }

--- a/patches/post/08_model_routing_protocol_data.patch
+++ b/patches/post/08_model_routing_protocol_data.patch
@@ -7,4 +7,6 @@ index 0d754fd..1b1f45c 100644
  	// Routing protocol type
  	Type_ string `json:"type,omitempty"`
 +	OneOfRoutingProtocolData
- }
+-}
++}
++

--- a/patches/post/08_model_routing_protocol_data.patch
+++ b/patches/post/08_model_routing_protocol_data.patch
@@ -1,0 +1,10 @@
+diff --git a/fabric/v4/model_routing_protocol_data.go b/fabric/v4/model_routing_protocol_data.go
+index 0d754fd..1b1f45c 100644
+--- a/fabric/v4/model_routing_protocol_data.go
++++ b/fabric/v4/model_routing_protocol_data.go
+@@ -12,4 +12,5 @@ package v4
+ type RoutingProtocolData struct {
+        // Routing protocol type
+        Type_ string `json:"type,omitempty"`
++       OneOfRoutingProtocolData
+ }

--- a/patches/post/08_model_routing_protocol_data.patch
+++ b/patches/post/08_model_routing_protocol_data.patch
@@ -7,6 +7,4 @@ index 0d754fd..1b1f45c 100644
  	// Routing protocol type
  	Type_ string `json:"type,omitempty"`
 +	OneOfRoutingProtocolData
--}
-+}
-+
+ }

--- a/patches/post/09_model_routing_protocol_base.patch
+++ b/patches/post/09_model_routing_protocol_base.patch
@@ -7,4 +7,6 @@ index 5020469..0523e39 100644
  	// Routing protocol type
  	Type_ string `json:"type,omitempty"`
 +	OneOfRoutingProtocolBase
- }
+-}
++}
++

--- a/patches/post/09_model_routing_protocol_base.patch
+++ b/patches/post/09_model_routing_protocol_base.patch
@@ -4,7 +4,7 @@ index 5020469..0523e39 100644
 +++ b/fabric/v4/model_routing_protocol_base.go
 @@ -12,4 +12,5 @@ package v4
  type RoutingProtocolBase struct {
-        // Routing protocol type
-        Type_ string `json:"type,omitempty"`
-+       OneOfRoutingProtocolBase
+ 	// Routing protocol type
+ 	Type_ string `json:"type,omitempty"`
++	OneOfRoutingProtocolBase
  }

--- a/patches/post/09_model_routing_protocol_base.patch
+++ b/patches/post/09_model_routing_protocol_base.patch
@@ -1,0 +1,10 @@
+diff --git a/fabric/v4/model_routing_protocol_base.go b/fabric/v4/model_routing_protocol_base.go
+index 5020469..0523e39 100644
+--- a/fabric/v4/model_routing_protocol_base.go
++++ b/fabric/v4/model_routing_protocol_base.go
+@@ -12,4 +12,5 @@ package v4
+ type RoutingProtocolBase struct {
+        // Routing protocol type
+        Type_ string `json:"type,omitempty"`
++       OneOfRoutingProtocolBase
+ }

--- a/patches/post/09_model_routing_protocol_base.patch
+++ b/patches/post/09_model_routing_protocol_base.patch
@@ -7,6 +7,4 @@ index 5020469..0523e39 100644
  	// Routing protocol type
  	Type_ string `json:"type,omitempty"`
 +	OneOfRoutingProtocolBase
--}
-+}
-+
+ }

--- a/patches/post/10_api_routing_protocols.patch
+++ b/patches/post/10_api_routing_protocols.patch
@@ -8,35 +8,35 @@ index 12f7efb..3a8aa30 100644
 
 +
 +func (a *RoutingProtocolsApiService) decodeRP(v *RoutingProtocolData, b []byte, contentType string) (err error) {
-+       //get type of response body
-+       var (
-+               localVarReturnBGP    RoutingProtocolBgpData
-+               localVarReturnDirect RoutingProtocolDirectData
-+       )
++	//get type of response body
++	var (
++		localVarReturnBGP    RoutingProtocolBgpData
++		localVarReturnDirect RoutingProtocolDirectData
++	)
 +
-+       err = a.client.decode(&v, b, contentType)
-+       if err != nil {
-+               return err
-+       }
-+       // decode response based on type, overwrite return value's oneof field
-+       if v.Type_ == "BGP" {
-+               // If we succeed, return the data, otherwise pass on to decode error.
-+               err = a.client.decode(&localVarReturnBGP, b, contentType)
-+               // try decoding as a bgp, return if no error
-+               if err == nil {
-+                       v.RoutingProtocolBgpData = localVarReturnBGP
-+                       return err
-+               }
-+       }
-+       if v.Type_ == "DIRECT" {
-+               // try decoding as a direct rp
-+               err = a.client.decode(&localVarReturnDirect, b, contentType)
-+               if err == nil {
-+                       v.RoutingProtocolDirectData = localVarReturnDirect
-+                       return err
-+               }
-+       }
-+       return err
++	err = a.client.decode(&v, b, contentType)
++	if err != nil {
++		return err
++	}
++	// decode response based on type, overwrite return value's oneof field
++	if v.Type_ == "BGP" {
++		// If we succeed, return the data, otherwise pass on to decode error.
++		err = a.client.decode(&localVarReturnBGP, b, contentType)
++		// try decoding as a bgp, return if no error
++		if err == nil {
++			v.RoutingProtocolBgpData = localVarReturnBGP
++			return err
++		}
++	}
++	if v.Type_ == "DIRECT" {
++		// try decoding as a direct rp
++		err = a.client.decode(&localVarReturnDirect, b, contentType)
++		if err == nil {
++			v.RoutingProtocolDirectData = localVarReturnDirect
++			return err
++		}
++	}
++	return err
 +}
 +
  /*
@@ -44,109 +44,108 @@ index 12f7efb..3a8aa30 100644
  This API provides capability to create Routing Protocol for connections
 @@ -90,8 +123,8 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
 
-        if localVarHttpResponse.StatusCode < 300 {
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
+-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+-		if err == nil {
++		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++		if err != nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+ 		}
+ 	}
+@@ -103,7 +136,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
+ 		}
+ 		if localVarHttpResponse.StatusCode == 202 {
+ 			var v RoutingProtocolData
+-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 			if err != nil {
+ 				newErr.error = err.Error()
+ 				return localVarReturnValue, localVarHttpResponse, newErr
+@@ -240,6 +273,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocolsInBulk(ctx
 
-                // If we succeed, return the data, otherwise pass on to decode error.
--               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
--               if err == nil {
-+               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+               if err != nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-                }
-        }
-@@ -102,7 +135,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
-                }
-                if localVarHttpResponse.StatusCode == 202 {
-                        var v RoutingProtocolData
--                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                        if err != nil {
-                                newErr.error = err.Error()
-                                return localVarReturnValue, localVarHttpResponse, newErr
-@@ -238,6 +271,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocolsInBulk(ctx
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
++		// fixme: why is this a get response?
+ 		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 		if err == nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+@@ -389,7 +423,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
 
-        if localVarHttpResponse.StatusCode < 300 {
-                // If we succeed, return the data, otherwise pass on to decode error.
-+               // fixme: why is this a get response?
-                err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                if err == nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-@@ -386,7 +420,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
+-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 		if err == nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+ 		}
+@@ -402,7 +436,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
+ 		}
+ 		if localVarHttpResponse.StatusCode == 202 {
+ 			var v RoutingProtocolData
+-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 			if err != nil {
+ 				newErr.error = err.Error()
+ 				return localVarReturnValue, localVarHttpResponse, newErr
+@@ -701,7 +735,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
 
-        if localVarHttpResponse.StatusCode < 300 {
-                // If we succeed, return the data, otherwise pass on to decode error.
--               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                if err == nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-                }
-@@ -399,7 +433,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
-                }
-                if localVarHttpResponse.StatusCode == 202 {
-                        var v RoutingProtocolData
--                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                        if err != nil {
-                                newErr.error = err.Error()
-                                return localVarReturnValue, localVarHttpResponse, newErr
-@@ -697,7 +731,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
+-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 		if err == nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+ 		}
+@@ -714,7 +748,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
+ 		}
+ 		if localVarHttpResponse.StatusCode == 200 {
+ 			var v RoutingProtocolData
+-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 			if err != nil {
+ 				newErr.error = err.Error()
+ 				return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1439,7 +1473,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
 
-        if localVarHttpResponse.StatusCode < 300 {
-                // If we succeed, return the data, otherwise pass on to decode error.
--               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                if err == nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-                }
-@@ -710,7 +744,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
-                }
-                if localVarHttpResponse.StatusCode == 200 {
-                        var v RoutingProtocolData
--                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                        if err != nil {
-                                newErr.error = err.Error()
-                                return localVarReturnValue, localVarHttpResponse, newErr
-@@ -1432,7 +1466,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
+-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 		if err == nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+ 		}
+@@ -1452,7 +1486,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
+ 		}
+ 		if localVarHttpResponse.StatusCode == 202 {
+ 			var v RoutingProtocolData
+-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 			if err != nil {
+ 				newErr.error = err.Error()
+ 				return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1743,7 +1777,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
 
-        if localVarHttpResponse.StatusCode < 300 {
-                // If we succeed, return the data, otherwise pass on to decode error.
--               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                if err == nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-                }
-@@ -1445,7 +1479,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
-                }
-                if localVarHttpResponse.StatusCode == 202 {
-                        var v RoutingProtocolData
--                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                        if err != nil {
-                                newErr.error = err.Error()
-                                return localVarReturnValue, localVarHttpResponse, newErr
-@@ -1734,7 +1768,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+ 	if localVarHttpResponse.StatusCode < 300 {
+ 		// If we succeed, return the data, otherwise pass on to decode error.
+-		err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++		err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 		if err == nil {
+ 			return localVarReturnValue, localVarHttpResponse, err
+ 		}
+@@ -1756,7 +1790,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+ 		}
+ 		if localVarHttpResponse.StatusCode == 202 {
+ 			var v RoutingProtocolData
+-			err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++			err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+ 			if err != nil {
+ 				newErr.error = err.Error()
+ 				return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1828,4 +1862,4 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+ 	}
 
-        if localVarHttpResponse.StatusCode < 300 {
-                // If we succeed, return the data, otherwise pass on to decode error.
--               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                if err == nil {
-                        return localVarReturnValue, localVarHttpResponse, err
-                }
-@@ -1747,7 +1781,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
-                }
-                if localVarHttpResponse.StatusCode == 202 {
-                        var v RoutingProtocolData
--                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-+                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
-                        if err != nil {
-                                newErr.error = err.Error()
-                                return localVarReturnValue, localVarHttpResponse, newErr
-@@ -1819,4 +1853,4 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
-        }
-
-        return localVarReturnValue, localVarHttpResponse, nil
+ 	return localVarReturnValue, localVarHttpResponse, nil
 -}
 +}
 \ No newline at end of file

--- a/patches/post/10_api_routing_protocols.patch
+++ b/patches/post/10_api_routing_protocols.patch
@@ -1,0 +1,152 @@
+diff --git a/fabric/v4/api_routing_protocols.go b/fabric/v4/api_routing_protocols.go
+index 12f7efb..3a8aa30 100644
+--- a/fabric/v4/api_routing_protocols.go
++++ b/fabric/v4/api_routing_protocols.go
+@@ -27,6 +27,39 @@ var (
+
+ type RoutingProtocolsApiService service
+
++
++func (a *RoutingProtocolsApiService) decodeRP(v *RoutingProtocolData, b []byte, contentType string) (err error) {
++       //get type of response body
++       var (
++               localVarReturnBGP    RoutingProtocolBgpData
++               localVarReturnDirect RoutingProtocolDirectData
++       )
++
++       err = a.client.decode(&v, b, contentType)
++       if err != nil {
++               return err
++       }
++       // decode response based on type, overwrite return value's oneof field
++       if v.Type_ == "BGP" {
++               // If we succeed, return the data, otherwise pass on to decode error.
++               err = a.client.decode(&localVarReturnBGP, b, contentType)
++               // try decoding as a bgp, return if no error
++               if err == nil {
++                       v.RoutingProtocolBgpData = localVarReturnBGP
++                       return err
++               }
++       }
++       if v.Type_ == "DIRECT" {
++               // try decoding as a direct rp
++               err = a.client.decode(&localVarReturnDirect, b, contentType)
++               if err == nil {
++                       v.RoutingProtocolDirectData = localVarReturnDirect
++                       return err
++               }
++       }
++       return err
++}
++
+ /*
+ RoutingProtocolsApiService Create Protocol
+ This API provides capability to create Routing Protocol for connections
+@@ -90,8 +123,8 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
+
+        if localVarHttpResponse.StatusCode < 300 {
+
+                // If we succeed, return the data, otherwise pass on to decode error.
+-               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+-               if err == nil {
++               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++               if err != nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+                }
+        }
+@@ -102,7 +135,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocol(ctx context
+                }
+                if localVarHttpResponse.StatusCode == 202 {
+                        var v RoutingProtocolData
+-                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                        if err != nil {
+                                newErr.error = err.Error()
+                                return localVarReturnValue, localVarHttpResponse, newErr
+@@ -238,6 +271,7 @@ func (a *RoutingProtocolsApiService) CreateConnectionRoutingProtocolsInBulk(ctx
+
+        if localVarHttpResponse.StatusCode < 300 {
+                // If we succeed, return the data, otherwise pass on to decode error.
++               // fixme: why is this a get response?
+                err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                if err == nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+@@ -386,7 +420,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
+
+        if localVarHttpResponse.StatusCode < 300 {
+                // If we succeed, return the data, otherwise pass on to decode error.
+-               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                if err == nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+                }
+@@ -399,7 +433,7 @@ func (a *RoutingProtocolsApiService) DeleteConnectionRoutingProtocolByUuid(ctx c
+                }
+                if localVarHttpResponse.StatusCode == 202 {
+                        var v RoutingProtocolData
+-                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                        if err != nil {
+                                newErr.error = err.Error()
+                                return localVarReturnValue, localVarHttpResponse, newErr
+@@ -697,7 +731,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
+
+        if localVarHttpResponse.StatusCode < 300 {
+                // If we succeed, return the data, otherwise pass on to decode error.
+-               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                if err == nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+                }
+@@ -710,7 +744,7 @@ func (a *RoutingProtocolsApiService) GetConnectionRoutingProtocolByUuid(ctx cont
+                }
+                if localVarHttpResponse.StatusCode == 200 {
+                        var v RoutingProtocolData
+-                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                        if err != nil {
+                                newErr.error = err.Error()
+                                return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1432,7 +1466,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
+
+        if localVarHttpResponse.StatusCode < 300 {
+                // If we succeed, return the data, otherwise pass on to decode error.
+-               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                if err == nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+                }
+@@ -1445,7 +1479,7 @@ func (a *RoutingProtocolsApiService) PatchConnectionRoutingProtocolByUuid(ctx co
+                }
+                if localVarHttpResponse.StatusCode == 202 {
+                        var v RoutingProtocolData
+-                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                        if err != nil {
+                                newErr.error = err.Error()
+                                return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1734,7 +1768,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+
+        if localVarHttpResponse.StatusCode < 300 {
+                // If we succeed, return the data, otherwise pass on to decode error.
+-               err = a.client.decode(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++               err = a.decodeRP(&localVarReturnValue, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                if err == nil {
+                        return localVarReturnValue, localVarHttpResponse, err
+                }
+@@ -1747,7 +1781,7 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+                }
+                if localVarHttpResponse.StatusCode == 202 {
+                        var v RoutingProtocolData
+-                       err = a.client.decode(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
++                       err = a.decodeRP(&v, localVarBody, localVarHttpResponse.Header.Get("Content-Type"))
+                        if err != nil {
+                                newErr.error = err.Error()
+                                return localVarReturnValue, localVarHttpResponse, newErr
+@@ -1819,4 +1853,4 @@ func (a *RoutingProtocolsApiService) ReplaceConnectionRoutingProtocolByUuid(ctx
+        }
+
+        return localVarReturnValue, localVarHttpResponse, nil
+-}
++}
+\ No newline at end of file


### PR DESCRIPTION
Includes updated changes from https://github.com/manu-equinix/fabric-go/tree/update-spec-4.7 and collaborated with @kehuang

Modifications include:  
* Custom decoder function for Routing Protocol APIs to handle differentiating DIRECT and BGP Routing Protocols
* Revised models to include `oneOf` routing protocol types (similar to SwaggerHub implementation)
```
fabric/v4/api_routing_protocols.go
fabric/v4/model_routing_protocol_base.go
fabric/v4/model_routing_protocol_data.go
```

The following files note these patches with their respective diffs:
```
patches/post/08_model_routing_protocol_data.patch
patches/post/09_model_routing_protocol_base.patch
patches/post/10_api_routing_protocols.patch
```