### PR TITLE
Modify Sync Workflow

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -24,7 +24,7 @@ jobs:
         API_SPEC_LINE=$(grep -i api.swaggerhub.com Makefile)
         CURRENT_VERSION_NUM=$(echo $API_SPEC_LINE | cut -d / -f7)
         VERSION_NUMS=($(echo "$CURRENT_VERSION_NUM" | tr . '\n'))
-        VERSION_NUMS[2]=$((VERSION_NUMS[2]+1))
+        VERSION_NUMS[1]=$((VERSION_NUMS[1]+1))
         echo "api_spec_line=$API_SPEC_LINE" >> "$GITHUB_OUTPUT"
         echo "cur_version=$CURRENT_VERSION_NUM" >> "$GITHUB_OUTPUT"
         echo "next_version=$(echo $(IFS=. ; echo "${VERSION_NUMS[*]}"))" >> "$GITHUB_OUTPUT"
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed -i '.bak' -e "s/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/" Makefile
+        sed "s/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/" Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -46,7 +46,7 @@ jobs:
       with:
         branch: sync/gh
         branch-suffix: timestamp
-        title: API Sync by GitHub Action (${{ steps.date.outputs.date }})
+        title: Version ${{ steps.spec_versions.outputs.cur_version }} to ${{ steps.spec_versions.outputs.next_version }} API Spec Sync by GitHub Action (${{ steps.date.outputs.date }})
         body: |
           This API Sync PR was automated through GitHub Actions workflow_displatch
           on ${{ steps.date.outputs.date }}.
@@ -62,11 +62,11 @@ jobs:
           
           ### Enhancements
           
-          - Add enhancements here -
+          -Add enhancements here-
           
           ### Breaking Changes
           
-          - Add breaking changes here -
+          -Add breaking changes here-
         delete-branch: true
     - name: Check outputs
       run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: equinix-product/interconnection_fabric-api-model
-        token: ${{ secrets.GITHUB_TOKEN
+        token: ${{ secrets.GITHUB_TOKEN }}
         path: fabric-api-model
     - name: Check Paths fomr Checkouts
       run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,5 @@
 on: [workflow_dispatch]
-name: Sync SDK with New API Spec
+name: Sync
 jobs:
   sync:
     strategy:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -30,9 +30,9 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: equinix-product/interconnection_fabric-api-model
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ssh-key: ${{ secrets.FABRIC_API_MODEL_DEPLOY_KEY }}
         path: fabric-api-model
-    - name: Check Paths fomr Checkouts
+    - name: Check Paths from Checkouts
       run: |
         ls -lrt ./fabric-go
         ls -lrt ./fabric-api-model

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed "s/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/" Makefile
+        sed 's/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed 's/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/' Makefile
+        sed 's,${{ steps.spec_versions.outputs.api_spec_line }},$VERSION_UPDATE,' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,4 +1,8 @@
-on: ["workflow_dispatch"]
+on:
+  workflow_dispatch:
+    inputs:
+      spec_file:
+        type: string
 name: Sync
 jobs:
   sync:
@@ -24,18 +28,9 @@ jobs:
         distribution: ${{ matrix.java-distribution }}
     - name: Checkout Go Code
       uses: actions/checkout@v2
-      with:
-        path: fabric-go
-    - name: Checkout Fabric API Model Private
-      uses: actions/checkout@v2
-      with:
-        repository: equinix-product/interconnection_fabric-api-model
-        ssh-key: ${{ secrets.FABRIC_API_MODEL_DEPLOY_KEY }}
-        path: fabric-api-model
-    - name: Check Paths from Checkouts
+    - name: Print spec_file input
       run: |
-        ls -lrt ./fabric-go
-        ls -lrt ./fabric-api-model
+        echo ${{ inputs.spec_file }}
     - name: GitHub user
       run: |
         # https://api.github.com/users/github-actions[bot]

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -6,7 +6,8 @@ jobs:
       matrix:
         go-version: [1.20.x]
         os: [ubuntu-latest]
-        java-version: [11.0.20]
+        java-version: [11.0.x]
+        java-distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Get current date
@@ -20,6 +21,7 @@ jobs:
       uses: actions/setup-java@v2
       with:
         java-version: ${{ matrix.java-version }}
+        distribution: ${{ matrix.java-distribution }}
     - name: Checkout Go Code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed 's,${{ steps.spec_versions.outputs.api_spec_line }},$VERSION_UPDATE,' Makefile
+        sed 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
+        sed -i '.bak' 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -6,6 +6,7 @@ jobs:
       matrix:
         go-version: [1.20.x]
         os: [ubuntu-latest]
+        java-version: [11.0.20]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Get current date
@@ -15,8 +16,24 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Checkout code
+    - name: Install Java
+      uses: actions/setup-java@v2
+      with:
+        java-version: ${{ matrix.java-version }}
+    - name: Checkout Go Code
       uses: actions/checkout@v2
+      with:
+        path: fabric-go
+    - name: Checkout Fabric API Model Private
+      uses: actions/checkout@v2
+      with:
+        repository: equinix-product/interconnection_fabric-api-model
+        token: ${{ secrets.GITHUB_TOKEN
+        path: fabric-api-model
+    - name: Check Paths fomr Checkouts
+      run: |
+        ls -lrt ./fabric-go
+        ls -lrt ./fabric-api-model
     - name: GitHub user
       run: |
         # https://api.github.com/users/github-actions[bot]

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,8 +1,4 @@
-on:
-  workflow_dispatch:
-    inputs:
-      spec_file:
-        type: string
+on: [workflow_dispatch]
 name: Sync
 jobs:
   sync:
@@ -10,27 +6,28 @@ jobs:
       matrix:
         go-version: [1.20.x]
         os: [ubuntu-latest]
-        java-version: [11.0.x]
-        java-distribution: [temurin]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Get current date
       id: date
       run: echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+
     - name: Install Go
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
-    - name: Install Java
-      uses: actions/setup-java@v2
-      with:
-        java-version: ${{ matrix.java-version }}
-        distribution: ${{ matrix.java-distribution }}
     - name: Checkout Go Code
       uses: actions/checkout@v2
-    - name: Print spec_file input
+    - name: Get next API Spec Version
+      id: spec_versions
       run: |
-        echo ${{ inputs.spec_file }}
+        API_SPEC_LINE=$(grep -i api.swaggerhub.com Makefile)
+        CURRENT_VERSION_NUM=$(echo $API_SPEC_LINE | cut -d / -f7)
+        VERSION_NUMS=($(echo "$CURRENT_VERSION_NUM" | tr . '\n'))
+        VERSION_NUMS[2]=$((VERSION_NUMS[2]+1))
+        echo "api_spec_line=$API_SPEC_LINE" >> "$GITHUB_OUTPUT"
+        echo "cur_version=$CURRENT_VERSION_NUM" >> "$GITHUB_OUTPUT"
+        echo "next_version=$(echo $(IFS=. ; echo "${VERSION_NUMS[*]}"))" >> "$GITHUB_OUTPUT"
     - name: GitHub user
       run: |
         # https://api.github.com/users/github-actions[bot]
@@ -38,22 +35,38 @@ jobs:
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
     - name: Sync
       run: |
+        VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
+        sed -i '.bak' -e "s/${{ steps.spec_versions.outputs.api_spec_line }}/$VERSION_UPDATE/" Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md
     - name: Create Pull Request
+      id: cpr
       uses: peter-evans/create-pull-request@v3
       with:
         branch: sync/gh
         branch-suffix: timestamp
         title: API Sync by GitHub Action (${{ steps.date.outputs.date }})
         body: |
-          This API Sync PR was automated through [GitHub Actions workflow_displatch](https://github.com/t0mk/gometal/actions?query=event%3Aworkflow_dispatch)
+          This API Sync PR was automated through GitHub Actions workflow_displatch
           on ${{ steps.date.outputs.date }}.
+          
+          This PR updates the SDK API Spec Version:
+          from ${{ steps.spec_versions.outputs.cur_version }} to ${{ steps.spec_versions.outputs.next_version }}
 
-          * latest Swagger is fetched
-          * patches have been applied
-          * generated client has been updated
+          * Latest Swaggerhub API Spec is fetched - version ${{ steps.spec_versions.outputs.next_version }}
+          * Patches have been applied
+          * Generated client has been updated
+          
+          ## Changes in SDK
+          
+          ### Enhancements
+          
+          - Add enhancements here -
+          
+          ### Breaking Changes
+          
+          - Add breaking changes here -
         delete-branch: true
     - name: Check outputs
       run: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed -i '.bak' 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
+        sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Sync
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ github.event.inputs.new_api_spec_version_number }}/swagger.yaml\""
-        sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},${{ github.event.inputs.new_api_spec_version_number }},' Makefile
+        sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -1,5 +1,9 @@
-on: [workflow_dispatch]
-name: Sync SDK with New API Spec
+on:
+  workflow_dispatch:
+    inputs:
+      new_api_spec_version_number:
+        required: true
+name: Sync # SDK with New API Spec
 jobs:
   sync:
     strategy:
@@ -23,11 +27,8 @@ jobs:
       run: |
         API_SPEC_LINE=$(grep -i api.swaggerhub.com Makefile)
         CURRENT_VERSION_NUM=$(echo $API_SPEC_LINE | cut -d / -f7)
-        VERSION_NUMS=($(echo "$CURRENT_VERSION_NUM" | tr . '\n'))
-        VERSION_NUMS[1]=$((VERSION_NUMS[1]+1))
         echo "api_spec_line=$API_SPEC_LINE" >> "$GITHUB_OUTPUT"
         echo "cur_version=$CURRENT_VERSION_NUM" >> "$GITHUB_OUTPUT"
-        echo "next_version=$(echo $(IFS=. ; echo "${VERSION_NUMS[*]}"))" >> "$GITHUB_OUTPUT"
     - name: GitHub user
       run: |
         # https://api.github.com/users/github-actions[bot]
@@ -35,8 +36,8 @@ jobs:
         git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
     - name: Sync
       run: |
-        VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ steps.spec_versions.outputs.next_version }}/swagger.yaml\""
-        sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
+        VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ github.event.inputs.new_api_spec_version_number }}/swagger.yaml\""
+        sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},${{ github.event.inputs.new_api_spec_version_number }},' Makefile
         make # pull fetch patch gen mod test
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md
@@ -46,15 +47,15 @@ jobs:
       with:
         branch: sync/gh
         branch-suffix: timestamp
-        title: Version ${{ steps.spec_versions.outputs.cur_version }} to ${{ steps.spec_versions.outputs.next_version }} API Spec Sync by GitHub Action (${{ steps.date.outputs.date }})
+        title: Version ${{ steps.spec_versions.outputs.cur_version }} to ${{ github.event.inputs.new_api_spec_version_number }} API Spec Sync by GitHub Action (${{ steps.date.outputs.date }})
         body: |
           This API Sync PR was automated through GitHub Actions workflow_displatch
           on ${{ steps.date.outputs.date }}.
           
           This PR updates the SDK API Spec Version:
-          from ${{ steps.spec_versions.outputs.cur_version }} to ${{ steps.spec_versions.outputs.next_version }}
+          from ${{ steps.spec_versions.outputs.cur_version }} to ${{ github.event.inputs.new_api_spec_version_number }}
 
-          * Latest Swaggerhub API Spec is fetched - version ${{ steps.spec_versions.outputs.next_version }}
+          * Latest Swaggerhub API Spec is fetched - version ${{ github.event.inputs.new_api_spec_version_number }}
           * Patches have been applied
           * Generated client has been updated
           

--- a/.github/workflows/sync_sdk_with_new_api_spec.yml
+++ b/.github/workflows/sync_sdk_with_new_api_spec.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         VERSION_UPDATE="SPEC_URL:=\"https://api.swaggerhub.com/apis/equinix-api/fabric/${{ github.event.inputs.new_api_spec_version_number }}/swagger.yaml\""
         sed -i 's,${{ steps.spec_versions.outputs.api_spec_line }},'"$VERSION_UPDATE"',' Makefile
-        make # pull fetch patch gen mod test
+        make
         git commit -m 'sync: fetch ${{ steps.date.outputs.date }} spec and apply patches' *.yaml
         git commit -m 'sync: generate client with ${{ steps.date.outputs.date }} spec' fabric api docs README.md
     - name: Create Pull Request

--- a/.github/workflows/sync_sdk_with_new_api_spec.yml
+++ b/.github/workflows/sync_sdk_with_new_api_spec.yml
@@ -1,5 +1,5 @@
 on: [workflow_dispatch]
-name: Sync
+name: Sync SDK with New API Spec
 jobs:
   sync:
     strategy:

--- a/.github/workflows/sync_sdk_with_new_api_spec.yml
+++ b/.github/workflows/sync_sdk_with_new_api_spec.yml
@@ -3,7 +3,7 @@ on:
     inputs:
       new_api_spec_version_number:
         required: true
-name: Sync # SDK with New API Spec
+name: Sync SDK with New API Spec
 jobs:
   sync:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.10/swagger.yaml"
+SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.11/swagger.yaml"
 SPEC_FETCHED_FILE:=spec.fetched.yaml
 SPEC_PATCHED_FILE:=spec.patched.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.9/swagger.yaml"
+SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.11/swagger.yaml"
 SPEC_FETCHED_FILE:=spec.fetched.yaml
 SPEC_PATCHED_FILE:=spec.patched.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.11/swagger.yaml"
+SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.10/swagger.yaml"
 SPEC_FETCHED_FILE:=spec.fetched.yaml
 SPEC_PATCHED_FILE:=spec.patched.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@
 CURRENT_UID := $(shell id -u)
 CURRENT_GID := $(shell id -g)
 
-SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.11/swagger.yaml"
+SPEC_URL:="https://api.swaggerhub.com/apis/equinix-api/fabric/4.9/swagger.yaml"
 SPEC_FETCHED_FILE:=spec.fetched.yaml
 SPEC_PATCHED_FILE:=spec.patched.yaml
 


### PR DESCRIPTION
* Rename workflow
* Automatically Increment Spec API Number
* Modify PR Title and Description
* Fix Output Check on PR Step by added `id: cpr`

Tested as `Sync` workflow before making the rename. Works as expected. See [PR 32](https://github.com/equinix-labs/fabric-go/pull/32) as last working example. (NOTE: The version number is input and the only way to get a change from 4.11 now is to go backwards. When 4.12 is released we can just update forward and the PR will be created.)